### PR TITLE
feat: allows to configure controller method to callback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "^6.0 || ^7.0",
-        "illuminate/auth": "^6.0 || ^7.0",
-        "illuminate/http": "^6.0 || ^7.0",
-        "illuminate/notifications": "^6.0 || ^7.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",
+        "illuminate/auth": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",
+        "illuminate/http": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",
+        "illuminate/notifications": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",
         "yaquawa/laravel-token-repository": "1.*"
     },
     "autoload": {

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ Add the following code to your `<config/auth.php>` file.
     'default' => [
         'table'  => 'email_resets',
         'expire' => 60,
+        'callback' => 'App\Http\Controllers\Auth\ResetEmailController@reset',
         // 'ignore-migrations' => true,
         // 'route' => 'email/reset/{token}',
     ]

--- a/src/EmailResetServiceProvider.php
+++ b/src/EmailResetServiceProvider.php
@@ -69,7 +69,7 @@ class EmailResetServiceProvider extends ServiceProvider
         if ( ! $this->app->routesAreCached()) {
             $route = Config::defaultDriverConfig('route') ?? 'email/reset/{token}';
 
-            Route::middleware(['web', 'auth'])->get($route, 'App\Http\Controllers\Auth\ResetEmailController@reset')->name('email-reset');
+            Route::middleware(['web', 'auth'])->get($route, Config::defaultDriverConfig('callback'))->name('email-reset');
         }
 
     }


### PR DESCRIPTION
If application doesn't use `App\Http\Controllers\Auth\ResetEmailController@reset` you can not use the vendor.
Also added laravel 5.* support in composer file, to respect laravel LTS.