### PR TITLE
feat(email-reset): update readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,116 +1,80 @@
-A Laravel package for resetting user email by sending a verification link to the new email.
+Laravel package to reset users emails
+1. send verification link to user's new email
+2. on click on verification link, new email is verified and changed
 
-This package reset the user's email by:
+## Installation process
+Follow few installation steps to set up vendor.
 
-1. Send verification link to user's new email.
-2. If the user clicks the verification link in their new email, the package will verify the new email and set the old email to the new one.
-
-## How to install
-To get started, follow the following steps.
-
-#### Installation
-
-`composer require yaquawa/laravel-email-reset`
-
-#### Configuration
-
-Add the following code to your `<config/auth.php>` file.
+### Prepare your App
+Edit `config/auth.php` config file and add the `email-reset` driver default configuration.
 
 ```php
-'defaults' => [
-    'guard'       => 'web',
-    'passwords'   => 'users',
-    'email-reset' => 'default' // Add this line
-],
+<?php
 
-// Add this entire block
-'email-reset' => [
-    'default' => [
-        'table'  => 'email_resets',
-        'expire' => 60,
-        'callback' => 'App\Http\Controllers\Auth\ResetEmailController@reset',
-        // 'ignore-migrations' => true,
-        // 'route' => 'email/reset/{token}',
-    ]
-]
+return [
+    'defaults' => [
+        // ...
+        'email-reset' => 'default' // Add this line
+        // ...
+    ],
+    // Add this entire block
+    'email-reset' => [
+        'default' => [
+            'table'  => 'email_resets',
+            'expire' => 60,
+            'callback' => 'App\Http\Controllers\Auth\ResetEmailController@reset',
+            'ignore-migrations' => false,
+            'route' => 'email/reset/{token}',
+        ]
+    ],
+];
 ```
 
-#### Migration 
- 
-`php artisan migrate`
+- `table`: **required**, database table name where will be store users new emails
+- `expire`: **required**, validation link validity expiration
+- `callback`: **required**, controller method that implement `ResetEmail` trait
+- `ignore-migrations`: **optional**, default value false; if you would like to use your own migration, set it to `true` (take inspiration from [migration file](https://github.com/yaquawa/laravel-email-reset/blob/master/database/migrations/2018_06_01_000001_create_email_resets_table.php)).
+- `route`: **optional**, default value `'email/reset/{token}'`
 
-If you would like to use your own migration, set `ignore-migrations` to `true` in the config file (See the migration file [here](https://github.com/yaquawa/laravel-email-reset/blob/master/database/migrations/2018_06_01_000001_create_email_resets_table.php)).
+### Vendor installation
+```shell
+composer require yaquawa/laravel-email-reset
+php artisan migrate
+```
 
-#### Publish the assets
-
-The following command publishes the package's controller and translation files to your app's directories.
-
+### Publish assets
 `php artisan vendor:publish --tag=laravel-email-reset`
 
-| Asset        | Location                                             |
-| ------------ | ---------------------------------------------------- |
-| Controller   | `app/Http/Controllers/Auth/ResetEmailController.php` |
-| Translations | `resources/lang/vendor/laravel-email-reset`          |
+Create following assets in your app:
+- `app/Http/Controllers/Auth/ResetEmailController.php`
+- `resources/lang/vendor/laravel-email-reset`
 
-#### Use the `CanResetEmail` trait
-
-In your `app/Models/User.php` file, use the `CanResetEmail` trait. This trait adds a `resetEmail` method to the user model.
+### Apply `CanResetEmail` trait in User model
+Edit your user model to use `CanResetEmail` trait.
 
 ```php
 namespace App\Models;
 
-use Yaquawa\Laravel\EmailReset\CanResetEmail;
-
 class User extends Authenticatable
 {
-    use CanResetEmail;
+    use \Yaquawa\Laravel\EmailReset\CanResetEmail;
 }
 ```
 
 ## Usage
-
 ### Send the verification email
+Once you added the `CanResetEmail` trait in your `User` model, you can use reset email features.
+Let's set new email for a user!
 
 ```php
-// By calling the `resetEmail` method of `User` instance,
-// an verification email will be sent to the user's new email address.
-// If the user clicked the verification link, the new email address will be set.
-
-// * The route of the verification link can be set at `route` in the config file.
- 
 $user->resetEmail('new_email@example.com');
 ```
 
-If you want to change the email contents, you can do something like this in your `AppServiceProvider.php`.
+Until user verified his new email, you can get the new email with `$user->new_email;`.
 
-```php
-namespace App\Providers;
-
-use Illuminate\Support\ServiceProvider;
-use Illuminate\Notifications\Messages\MailMessage;
-use Yaquawa\Laravel\EmailReset\Notifications\EmailResetNotification;
-
-class AppServiceProvider extends ServiceProvider
-{
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        EmailResetNotification::toMailUsing(function ($user, $token, $resetLink) {
-            return (new MailMessage)
-                ->line('You are receiving this email because we received a email reset request for your account.')
-                ->action('Reset Email', $resetLink)
-                ->line('If you did not request a email reset, no further action is required.');
-        });
-    }
-}
-```
-
-After the user clicked the verification link, by default, the user will be redirected to the root of your app URL.
-You can change this behavior by overriding the methods of the published controller `ResetEmailController`.
+The user will receive a validation link at `new_email@example.com`.
+By default, when the user clicked the verification link, he will be redirected to the root of your App URL.
+You can change this behavior by overriding `ResetEmail` trait methods in your controller `ResetEmailController`.
 
 ```php
 namespace App\Http\Controllers\Auth;
@@ -132,7 +96,8 @@ class ResetEmailController extends Controller
      */
     protected function sendResetFailedResponse(string $status)
     {
-        return redirect($this->redirectPathForFailure())->withErrors(['laravel-email-reset' => trans($status)]);
+        return redirect($this->redirectPathForFailure())
+            ->withErrors(['laravel-email-reset' => trans($status)]);
     }
 
     /**
@@ -146,11 +111,12 @@ class ResetEmailController extends Controller
      */
     protected function sendResetResponse(string $status)
     {
-        return redirect($this->redirectPathForSuccess())->with('laravel-email-reset', trans($status));
+        return redirect($this->redirectPathForSuccess())
+            ->with('laravel-email-reset', trans($status));
     }
 
     /**
-     * The redirect path for failure.
+     * The redirect URI for failure.
      *
      * @return string
      */
@@ -160,7 +126,7 @@ class ResetEmailController extends Controller
     }
 
     /**
-     * The redirect path for success.
+     * The redirect URI for success.
      *
      * @return string
      */
@@ -168,15 +134,34 @@ class ResetEmailController extends Controller
     {
         return '/';
     }
-    
 }
 ```
 
-### Retrieve the "new email"
-
-The new email won't be saved until the user clicks the verification link.
-Before user clicking the verification link you can get the new email by:
+If you want to change the email contents, you can do something like this in your `AppServiceProvider.php` (do more with [laravel notifications doc](https://laravel.com/docs/7.x/notifications)).
 
 ```php
-$user->new_email; // retrieve the `new_email` from database
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Notifications\Messages\MailMessage;
+use Yaquawa\Laravel\EmailReset\Notifications\EmailResetNotification;
+
+class AppServiceProvider extends ServiceProvider
+{
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        EmailResetNotification::toMailUsing(function ($user, $token, $resetLink) {
+            return (new MailMessage)
+                ->line('You are receiving this email because we received a email reset request for your account.')
+                ->action('Reset Email', $resetLink)
+                ->line('If you did not request a email reset, no further action is required.');
+        });
+    }
+}
 ```


### PR DESCRIPTION
This PR update the readme with my point of view to how to present the email reset vendor.

Main modifications:
- wording
- text blocks organisation

I tried to do not distort the existing one.
Open to any comments to improve this proposal.